### PR TITLE
Support Bearer Token Authentication

### DIFF
--- a/AxosoftAPI.NET/AxosoftAPI.NET.csproj
+++ b/AxosoftAPI.NET/AxosoftAPI.NET.csproj
@@ -164,6 +164,7 @@
     <Compile Include="ScopeEnum.cs" />
     <Compile Include="SecurityRoles.cs" />
     <Compile Include="Tasks.cs" />
+    <Compile Include="TokenTypeEnum.cs" />
     <Compile Include="Users.cs" />
     <Compile Include="VersionEnum.cs" />
     <Compile Include="Workflows.cs" />

--- a/AxosoftAPI.NET/AxosoftAPI.NET.nuspec
+++ b/AxosoftAPI.NET/AxosoftAPI.NET.nuspec
@@ -2,7 +2,7 @@
 <package >
 	<metadata>
 		<id>$id$</id>
-		<version>6.0.2.0</version>
+		<version>6.0.3.0</version>
 		<title>$title$</title>
 		<authors>$author$</authors>
 		<owners>$author$</owners>

--- a/AxosoftAPI.NET/Core/BaseRequest.cs
+++ b/AxosoftAPI.NET/Core/BaseRequest.cs
@@ -78,7 +78,8 @@ namespace AxosoftAPI.NET.Core
 			// Add OAuth header (X-Authorization)
 			if (!string.IsNullOrWhiteSpace(client.AccessToken))
 			{
-				request.Headers.Add("X-Authorization", string.Format(@"OAuth {0}", client.AccessToken));
+				var tokenType = client.AccessTokenType.GetDescription();
+				request.Headers.Add("X-Authorization", string.Format(@"{0} {1}", tokenType, client.AccessToken));
 			}
 
 			// Return http request 

--- a/AxosoftAPI.NET/Core/Interfaces/IPicklistResource.cs
+++ b/AxosoftAPI.NET/Core/Interfaces/IPicklistResource.cs
@@ -2,7 +2,7 @@
 
 namespace AxosoftAPI.NET.Core.Interfaces
 {
-	public interface IPicklistResource<T> : ICreateResource<T>, IDeleteResource<T>
+	public interface IPicklistResource<T> : ICreateResource<T>, IDeleteResource<T>, IGetAllResource<T>, IGetResource<T>
 	{
 	}
 }

--- a/AxosoftAPI.NET/Interfaces/IProxy.cs
+++ b/AxosoftAPI.NET/Interfaces/IProxy.cs
@@ -14,6 +14,8 @@ namespace AxosoftAPI.NET.Interfaces
 
 		string AccessToken { get; set; }
 
+		TokenTypeEnum AccessTokenType { get; set; }
+
 		bool HasAccessToken { get; }
 	}
 }

--- a/AxosoftAPI.NET/Models/AuthResponse.cs
+++ b/AxosoftAPI.NET/Models/AuthResponse.cs
@@ -6,5 +6,8 @@ namespace AxosoftAPI.NET.Models
 	{
 		[JsonProperty("access_token")]
 		public string AccessToken { get; set; }
+
+		[JsonProperty("token_type")]
+		public string TokenType { get; set; }
 	}
 }

--- a/AxosoftAPI.NET/Models/BaseModel.cs
+++ b/AxosoftAPI.NET/Models/BaseModel.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace AxosoftAPI.NET.Models
 {
@@ -25,5 +27,8 @@ namespace AxosoftAPI.NET.Models
 
 		[JsonProperty("last_updated_by")]
 		public User LastUpdatedBy { get; set; }
+
+		[JsonExtensionData(ReadData = true, WriteData = true)]
+		public Dictionary<string, JToken> ExtensionData { get; set; }
 	}
 }

--- a/AxosoftAPI.NET/Properties/AssemblyInfo.cs
+++ b/AxosoftAPI.NET/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("6.0.2.0")]
-[assembly: AssemblyFileVersion("6.0.2.0")]
+[assembly: AssemblyVersion("6.0.3.0")]
+[assembly: AssemblyFileVersion("6.0.3.0")]

--- a/AxosoftAPI.NET/TokenTypeEnum.cs
+++ b/AxosoftAPI.NET/TokenTypeEnum.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.ComponentModel;
+
+namespace AxosoftAPI.NET
+{
+	public enum TokenTypeEnum
+	{
+		[Description("OAuth")]
+		OAuth,
+		[Description("Bearer")]
+		Bearer
+	}
+}


### PR DESCRIPTION
Current documentation (07/20/2017) stipulates the use of a Bearer token rather than the OAuth token authentication scheme using the AuthenticationCode path

http://developer.axosoft.com/authentication/authorization-code.html